### PR TITLE
Google Analytics を環境変数経由で追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Google Analytics 測定ID
+# Netlify のダッシュボード → Site configuration → Environment variables で設定する
+PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ interface Props {
 }
 
 const { title, description = '自由から揚げ財団 — 自由から揚げ運動を推進する非営利団体' } = Astro.props;
+const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
 ---
 
 <!doctype html>
@@ -21,6 +22,17 @@ const { title, description = '自由から揚げ財団 — 自由から揚げ運
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0&icon_names=keyboard_double_arrow_down" rel="stylesheet" />
     <title>{title}</title>
+    {gaMeasurementId && (
+      <>
+        <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}></script>
+        <script define:vars={{ gaMeasurementId }}>
+          window.dataLayer = window.dataLayer || [];
+          function gtag() { dataLayer.push(arguments); }
+          gtag('js', new Date());
+          gtag('config', gaMeasurementId);
+        </script>
+      </>
+    )}
   </head>
   <body class="bg-cream-100 text-brown-900 font-sans antialiased">
     <slot />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,7 +27,8 @@ const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
         <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}></script>
         <script define:vars={{ gaMeasurementId }}>
           window.dataLayer = window.dataLayer || [];
-          function gtag() { dataLayer.push(arguments); }
+          function gtag() { window.dataLayer.push(arguments); }
+          window.gtag = gtag;
           gtag('js', new Date());
           gtag('config', gaMeasurementId);
         </script>


### PR DESCRIPTION
PUBLIC_GA_MEASUREMENT_ID 環境変数が設定されている場合のみ GA
  スクリプトを挿入。測定 ID はリポジトリに含めず Netlify の環境変数で管理。