### PR TITLE
モバイルでの日本語テキスト不自然な改行を修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,9 @@ import Layout from '../layouts/Layout.astro';
 
     <div class="relative max-w-4xl mx-auto">
       <h1 class="font-serif text-5xl md:text-7xl font-bold text-brown-900 leading-tight mb-6">
-        <span class="whitespace-nowrap">からあげを</span><br class="hidden md:block" /><span class="text-karaage-gold whitespace-nowrap">自由に</span>
+        <span class="whitespace-nowrap">からあげを</span>
+        <br class="hidden md:block" />
+        <span class="text-karaage-gold whitespace-nowrap">自由に</span>
       </h1>
       <p class="text-xl md:text-2xl text-brown-700 font-light leading-relaxed mb-4 max-w-2xl mx-auto">
         レモンをかけるかどうかは、<span class="whitespace-nowrap">あなたが決める。</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,9 +30,7 @@ import Layout from '../layouts/Layout.astro';
 
     <div class="relative max-w-4xl mx-auto">
       <h1 class="font-serif text-5xl md:text-7xl font-bold text-brown-900 leading-tight mb-6">
-        <span class="whitespace-nowrap">からあげを</span>
-        <br class="hidden md:block" />
-        <span class="text-karaage-gold whitespace-nowrap">自由に</span>
+        <span class="whitespace-nowrap">からあげを</span><br class="hidden md:block" /><span class="text-karaage-gold whitespace-nowrap">自由に</span>
       </h1>
       <p class="text-xl md:text-2xl text-brown-700 font-light leading-relaxed mb-4 max-w-2xl mx-auto">
         レモンをかけるかどうかは、<span class="whitespace-nowrap">あなたが決める。</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,11 +30,10 @@ import Layout from '../layouts/Layout.astro';
 
     <div class="relative max-w-4xl mx-auto">
       <h1 class="font-serif text-5xl md:text-7xl font-bold text-brown-900 leading-tight mb-6">
-        からあげを<br class="hidden md:block" />
-        <span class="text-karaage-gold whitespace-nowrap">自由に</span>
+        <span class="whitespace-nowrap">からあげを</span><br class="hidden md:block" /><span class="text-karaage-gold whitespace-nowrap">自由に</span>
       </h1>
       <p class="text-xl md:text-2xl text-brown-700 font-light leading-relaxed mb-4 max-w-2xl mx-auto">
-        レモンをかけるかどうかは、あなたが決める。
+        レモンをかけるかどうかは、<span class="whitespace-nowrap">あなたが決める。</span>
       </p>
       <p class="text-base md:text-lg text-brown-600 leading-relaxed mb-12 max-w-2xl mx-auto">
         自由からあげ財団は、すべての人があらゆる制約から解放され、

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,7 +31,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="relative max-w-4xl mx-auto">
       <h1 class="font-serif text-5xl md:text-7xl font-bold text-brown-900 leading-tight mb-6">
         からあげを<br class="hidden md:block" />
-        <span class="text-karaage-gold">自由に</span>
+        <span class="text-karaage-gold whitespace-nowrap">自由に</span>
       </h1>
       <p class="text-xl md:text-2xl text-brown-700 font-light leading-relaxed mb-4 max-w-2xl mx-auto">
         レモンをかけるかどうかは、あなたが決める。

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -19,7 +19,7 @@
   --font-family-serif: 'Noto Serif JP', Georgia, serif;
 }
 
-/* 日本語の改行ルール */
+/* 長い単語や文字列のはみ出し防止 */
 :root {
   overflow-wrap: break-word;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,6 +24,6 @@
   overflow-wrap: break-word;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h2, h3, h4, h5, h6 {
   text-wrap: balance;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,3 +18,12 @@
   --font-family-sans: 'Noto Sans JP', system-ui, sans-serif;
   --font-family-serif: 'Noto Serif JP', Georgia, serif;
 }
+
+/* 日本語の改行ルール */
+:root {
+  overflow-wrap: break-word;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  text-wrap: balance;
+}


### PR DESCRIPTION
## Summary

- `src/styles/global.css`: `h2`〜`h6` に `text-wrap: balance` を適用（h1 は手動 `<br>` で制御するため除外）
- `src/styles/global.css`: `:root` に `overflow-wrap: break-word` を追加
- `src/pages/index.astro`: h1「からあげを」「自由に」をそれぞれ `whitespace-nowrap` で保護し、フレーズ途中での改行を禁止
- `src/pages/index.astro`: タグライン「あなたが決める。」を `whitespace-nowrap` で保護

## Test plan

- [ ] `npm run dev` で起動し、Chrome DevTools のモバイルビュー（375px など）で確認
- [ ] h1「からあげを / 自由に」が不自然な位置で分割されないことを確認
- [ ] 「レモンをかけるかどうかは、あなたが決める。」が「あなたが決める。」の途中で折り返されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)