### PR TITLE
フォントを BIZ UDPGothic / BIZ UDPMincho（UDフォント）に変更

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&family=BIZ+UDPMincho:wght@400;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0&icon_names=keyboard_double_arrow_down" rel="stylesheet" />
     <title>{title}</title>
     {gaMeasurementId && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,8 +15,8 @@
   --color-brown-700: #5a3810;
   --color-brown-600: #7a5020;
 
-  --font-family-sans: 'Noto Sans JP', system-ui, sans-serif;
-  --font-family-serif: 'Noto Serif JP', Georgia, serif;
+  --font-family-sans: 'BIZ UDPGothic', system-ui, sans-serif;
+  --font-family-serif: 'BIZ UDPMincho', Georgia, serif;
 }
 
 /* 長い単語や文字列のはみ出し防止 */


### PR DESCRIPTION
## 変更内容

Noto Sans/Serif JP からユニバーサルデザインフォント（BIZ UDP）へ切り替え。

- Noto Sans JP → BIZ UDPGothic（ゴシック体）
- Noto Serif JP → BIZ UDPMincho（明朝体）

BIZ UDP は Morisawa が開発したユニバーサルデザインフォントで、Google Fonts から無償で利用できます。文字の視認性・可読性が高く、様々な環境で読みやすい特徴があります。

## 変更ファイル

- `src/layouts/Layout.astro` — Google Fonts の読み込みURLを更新
- `src/styles/global.css` — フォントファミリーのトークンを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)