### PR TITLE
「四つの自由」の表記をアラビア数字に統一

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ import Layout from '../layouts/Layout.astro';
         <span class="font-serif font-bold text-brown-900 text-sm tracking-wide">自由からあげ財団</span>
       </a>
       <div class="hidden md:flex items-center gap-8 text-sm font-medium text-brown-700">
-        <a href="#freedoms" class="hover:text-karaage-gold transition-colors">四つの自由</a>
+        <a href="#freedoms" class="hover:text-karaage-gold transition-colors">4つの自由</a>
         <a href="#manifesto" class="hover:text-karaage-gold transition-colors">宣言</a>
         <a href="#about" class="hover:text-karaage-gold transition-colors">概要</a>
         <a href="#join" class="bg-karaage-gold text-white px-4 py-2 rounded-full hover:bg-karaage-dark transition-colors">参加する</a>
@@ -41,7 +41,7 @@ import Layout from '../layouts/Layout.astro';
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a href="#freedoms" class="bg-karaage-gold text-white px-8 py-4 rounded-full font-medium text-lg hover:bg-karaage-dark transition-all hover:shadow-lg hover:shadow-karaage-gold/20 hover:-translate-y-0.5">
-          四つの自由を読む
+          4つの自由を読む
         </a>
         <a href="#manifesto" class="border-2 border-brown-800 text-brown-900 px-8 py-4 rounded-full font-medium text-lg hover:bg-brown-800 hover:text-cream-100 transition-all">
           自由からあげ宣言
@@ -265,7 +265,7 @@ import Layout from '../layouts/Layout.astro';
           </div>
         </div>
         <div class="flex gap-8 text-sm text-brown-500">
-          <a href="#freedoms" class="hover:text-karaage-amber transition-colors">四つの自由</a>
+          <a href="#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
           <a href="#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
           <a href="#about" class="hover:text-karaage-amber transition-colors">概要</a>
         </div>


### PR DESCRIPTION
## Summary

- ヘッダーナビ・CTAボタン・フッターナビで「四つの自由」と「4つの自由」が混在していた表記を「4つの自由」に統一

## Test plan

- [ ] ヘッダーナビの「4つの自由」リンクを確認
- [ ] CTAボタンの「4つの自由を読む」を確認
- [ ] フッターナビの「4つの自由」リンクを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)