### PR TITLE
フッターに GitHub ソースコードリンクを追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -268,6 +268,7 @@ import Layout from '../layouts/Layout.astro';
           <a href="#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
           <a href="#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
           <a href="#about" class="hover:text-karaage-amber transition-colors">概要</a>
+          <a href="https://github.com/cyber-gene/fkf" class="hover:text-karaage-amber transition-colors" target="_blank" rel="noopener">ソースコード</a>
         </div>
       </div>
       <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -268,16 +268,22 @@ import Layout from '../layouts/Layout.astro';
           <a href="#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
           <a href="#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
           <a href="#about" class="hover:text-karaage-amber transition-colors">概要</a>
-          <a href="https://github.com/cyber-gene/fkf" class="hover:text-karaage-amber transition-colors" target="_blank" rel="noopener">ソースコード</a>
         </div>
       </div>
-      <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600">
+      <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600 space-y-2">
         <p>
           自由からあげ財団のコンテンツは、
           <a href="https://www.gnu.org/licenses/copyleft.html" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
             コピーレフト
           </a>
           の精神のもと自由に共有できます。
+        </p>
+        <p>
+          ソースコードは
+          <a href="https://github.com/cyber-gene/fkf" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
+            GitHub
+          </a>
+          にて AGPL-3.0 のもと公開しています。
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- フッターのナビゲーションに「ソースコード」リンクを追加（`https://github.com/cyber-gene/fkf`）
- AGPL-3.0 ライセンスのもと、ネットワーク越しに利用するユーザーへのソースコードアクセス提供が目的

## Test plan

- [ ] フッターに「ソースコード」リンクが表示されることを確認
- [ ] リンクが GitHub リポジトリへ正しく遷移することを確認（新しいタブで開く）

🤖 Generated with [Claude Code](https://claude.com/claude-code)