### PR TITLE
フッターのサブテキストを団体の説明に変更

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -261,7 +261,7 @@ import Layout from '../layouts/Layout.astro';
           <img src="/favicon.svg" alt="からあげ" class="w-9 h-9 object-contain" />
           <div>
             <p class="font-serif font-bold text-cream-100">自由からあげ財団</p>
-            <p class="text-sm text-brown-600">自由からあげ運動</p>
+            <p class="text-sm text-brown-600">食卓の自由を守る非営利団体</p>
           </div>
         </div>
         <div class="flex gap-8 text-sm text-brown-500">


### PR DESCRIPTION
## Summary

- フッターの財団名直下のテキストを「自由からあげ運動」→「食卓の自由を守る非営利団体」に変更
- 財団名と運動名を並べるより、この団体が何者かを端的に示す説明の方が適切

🤖 Generated with [Claude Code](https://claude.com/claude-code)