### PR TITLE
「作り方を知る自由」の説明文を自然な日本語に修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,8 +93,8 @@ import Layout from '../layouts/Layout.astro';
               <h3 class="font-serif text-xl font-bold text-brown-900 mb-3">作り方を知る自由</h3>
               <p class="text-brown-600 leading-relaxed">
                 からあげの製法・材料・工程を知り、自分で再現する権利。
-                「秘伝のタレ」という名の不透明性を拒否し、
-                からあげのレシピはオープンであるべきだ。
+                レシピはオープンであるべきで、
+                「秘伝のタレ」という名の不透明性に正当性はない。
               </p>
             </div>
           </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,7 +93,7 @@ import Layout from '../layouts/Layout.astro';
               <h3 class="font-serif text-xl font-bold text-brown-900 mb-3">作り方を知る自由</h3>
               <p class="text-brown-600 leading-relaxed">
                 からあげの製法・材料・工程を知り、自分で再現する権利。
-                レシピはオープンであるべきで、
+                からあげのレシピはオープンであるべきで、
                 「秘伝のタレ」という名の不透明性に正当性はない。
               </p>
             </div>


### PR DESCRIPTION
## Summary

- 「作り方を知る自由」の説明文が日本語として不自然だった箇所を修正
- 「権利。」で文が終わった後に「不透明性を拒否し、」と繋がる構成を改め、論理的に一本筋の通った流れに書き直し

**変更前:**
> 「秘伝のタレ」という名の不透明性を拒否し、からあげのレシピはオープンであるべきだ。

**変更後:**
> レシピはオープンであるべきで、「秘伝のタレ」という名の不透明性に正当性はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)