### PR TITLE
「四つの本質的な自由」をアラビア数字「4つ」に統一

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,7 +62,7 @@ import Layout from '../layouts/Layout.astro';
         <p class="text-karaage-gold font-medium tracking-widest uppercase text-sm mb-4">The Four Freedoms</p>
         <h2 class="font-serif text-4xl md:text-5xl font-bold text-brown-900 mb-6">自由からあげ運動の4つの自由</h2>
         <p class="text-brown-600 text-lg max-w-2xl mx-auto">
-          自由からあげ財団は、からあげを真に自由に楽しむために必要な、四つの本質的な自由を定義しました。
+          自由からあげ財団は、からあげを真に自由に楽しむために必要な、4つの本質的な自由を定義しました。
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

- 4つの自由セクションの説明文に残っていた「四つの本質的な自由」を「4つの本質的な自由」に修正
- PR #8 で対応した表記統一の漏れ

🤖 Generated with [Claude Code](https://claude.com/claude-code)