### PR TITLE
プライバシーポリシーページを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist
 
 # OS
 .DS_Store
+
+# Claude Code
+.claude/

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,3 @@
----
----
-
 <footer class="bg-brown-900 text-cream-200 py-12 px-6">
   <div class="max-w-6xl mx-auto">
     <div class="flex flex-col md:flex-row justify-between items-center gap-6">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,40 @@
+---
+---
+
+<footer class="bg-brown-900 text-cream-200 py-12 px-6">
+  <div class="max-w-6xl mx-auto">
+    <div class="flex flex-col md:flex-row justify-between items-center gap-6">
+      <div class="flex items-center gap-3">
+        <img src="/favicon.svg" alt="からあげ" class="w-9 h-9 object-contain" />
+        <div>
+          <p class="font-serif font-bold text-cream-100">自由からあげ財団</p>
+          <p class="text-sm text-brown-600">食卓の自由を守る非営利団体</p>
+        </div>
+      </div>
+      <div class="flex gap-8 text-sm text-brown-500">
+        <a href="/#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
+        <a href="/#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
+        <a href="/#about" class="hover:text-karaage-amber transition-colors">概要</a>
+      </div>
+    </div>
+    <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600 space-y-2">
+      <p>
+        自由からあげ財団のコンテンツは、
+        <a href="https://www.gnu.org/licenses/copyleft.html" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
+          コピーレフト
+        </a>
+        の精神のもと自由に共有できます。
+      </p>
+      <p>
+        ソースコードは
+        <a href="https://github.com/cyber-gene/fkf" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
+          GitHub
+        </a>
+        にて AGPL-3.0 のもと公開しています。
+      </p>
+      <p>
+        <a href="/privacy" class="text-karaage-amber hover:underline">プライバシーポリシー</a>
+      </p>
+    </div>
+  </div>
+</footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,6 +3,7 @@ const navLinks = [
   { href: '/#freedoms', label: '4つの自由' },
   { href: '/#manifesto', label: '宣言' },
   { href: '/#about', label: '概要' },
+  { href: '/#join', label: '参加する', isCta: true },
 ];
 ---
 
@@ -13,10 +14,14 @@ const navLinks = [
       <span class="font-serif font-bold text-brown-900 text-sm tracking-wide">自由からあげ財団</span>
     </a>
     <div class="hidden md:flex items-center gap-8 text-sm font-medium text-brown-700">
-      {navLinks.map(({ href, label }) => (
-        <a href={href} class="hover:text-karaage-gold transition-colors">{label}</a>
+      {navLinks.map(({ href, label, isCta }) => (
+        <a
+          href={href}
+          class={isCta
+            ? 'bg-karaage-gold text-white px-4 py-2 rounded-full hover:bg-karaage-dark transition-colors'
+            : 'hover:text-karaage-gold transition-colors'}
+        >{label}</a>
       ))}
-      <a href="/#join" class="bg-karaage-gold text-white px-4 py-2 rounded-full hover:bg-karaage-dark transition-colors">参加する</a>
     </div>
   </div>
 </nav>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,0 +1,22 @@
+---
+const navLinks = [
+  { href: '/#freedoms', label: '4つの自由' },
+  { href: '/#manifesto', label: '宣言' },
+  { href: '/#about', label: '概要' },
+];
+---
+
+<nav class="fixed top-0 left-0 right-0 z-50 bg-cream-100/90 backdrop-blur-sm border-b border-cream-200">
+  <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+    <a href="/" class="flex items-center gap-2">
+      <img src="/favicon.svg" alt="からあげ" class="w-7 h-7 object-contain" />
+      <span class="font-serif font-bold text-brown-900 text-sm tracking-wide">自由からあげ財団</span>
+    </a>
+    <div class="hidden md:flex items-center gap-8 text-sm font-medium text-brown-700">
+      {navLinks.map(({ href, label }) => (
+        <a href={href} class="hover:text-karaage-gold transition-colors">{label}</a>
+      ))}
+      <a href="/#join" class="bg-karaage-gold text-white px-4 py-2 rounded-full hover:bg-karaage-dark transition-colors">参加する</a>
+    </div>
+  </div>
+</nav>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -285,6 +285,9 @@ import Layout from '../layouts/Layout.astro';
           </a>
           にて AGPL-3.0 のもと公開しています。
         </p>
+        <p>
+          <a href="/privacy" class="text-karaage-amber hover:underline">プライバシーポリシー</a>
+        </p>
       </div>
     </div>
   </footer>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,24 +1,12 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
 ---
 
 <Layout title="自由からあげ財団">
 
-  <!-- Navigation -->
-  <nav class="fixed top-0 left-0 right-0 z-50 bg-cream-100/90 backdrop-blur-sm border-b border-cream-200">
-    <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-      <a href="#" class="flex items-center gap-2">
-        <img src="/favicon.svg" alt="からあげ" class="w-7 h-7 object-contain" />
-        <span class="font-serif font-bold text-brown-900 text-sm tracking-wide">自由からあげ財団</span>
-      </a>
-      <div class="hidden md:flex items-center gap-8 text-sm font-medium text-brown-700">
-        <a href="#freedoms" class="hover:text-karaage-gold transition-colors">4つの自由</a>
-        <a href="#manifesto" class="hover:text-karaage-gold transition-colors">宣言</a>
-        <a href="#about" class="hover:text-karaage-gold transition-colors">概要</a>
-        <a href="#join" class="bg-karaage-gold text-white px-4 py-2 rounded-full hover:bg-karaage-dark transition-colors">参加する</a>
-      </div>
-    </div>
-  </nav>
+  <Header />
 
   <!-- Hero -->
   <section class="min-h-screen flex flex-col items-center justify-center px-6 pt-20 pb-16 text-center relative overflow-hidden">
@@ -253,44 +241,7 @@ import Layout from '../layouts/Layout.astro';
     </div>
   </section>
 
-  <!-- Footer -->
-  <footer class="bg-brown-900 text-cream-200 py-12 px-6">
-    <div class="max-w-6xl mx-auto">
-      <div class="flex flex-col md:flex-row justify-between items-center gap-6">
-        <div class="flex items-center gap-3">
-          <img src="/favicon.svg" alt="からあげ" class="w-9 h-9 object-contain" />
-          <div>
-            <p class="font-serif font-bold text-cream-100">自由からあげ財団</p>
-            <p class="text-sm text-brown-600">食卓の自由を守る非営利団体</p>
-          </div>
-        </div>
-        <div class="flex gap-8 text-sm text-brown-500">
-          <a href="#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
-          <a href="#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
-          <a href="#about" class="hover:text-karaage-amber transition-colors">概要</a>
-        </div>
-      </div>
-      <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600 space-y-2">
-        <p>
-          自由からあげ財団のコンテンツは、
-          <a href="https://www.gnu.org/licenses/copyleft.html" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
-            コピーレフト
-          </a>
-          の精神のもと自由に共有できます。
-        </p>
-        <p>
-          ソースコードは
-          <a href="https://github.com/cyber-gene/fkf" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
-            GitHub
-          </a>
-          にて AGPL-3.0 のもと公開しています。
-        </p>
-        <p>
-          <a href="/privacy" class="text-karaage-amber hover:underline">プライバシーポリシー</a>
-        </p>
-      </div>
-    </div>
-  </footer>
+  <Footer />
 
 </Layout>
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,170 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout
+  title="プライバシーポリシー — 自由からあげ財団"
+  description="自由からあげ財団のプライバシーポリシー。Google Analytics の利用とデータ収集について説明します。"
+>
+
+  <!-- Navigation -->
+  <nav class="fixed top-0 left-0 right-0 z-50 bg-cream-100/90 backdrop-blur-sm border-b border-cream-200">
+    <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/favicon.svg" alt="からあげ" class="w-7 h-7 object-contain" />
+        <span class="font-serif font-bold text-brown-900 text-sm tracking-wide">自由からあげ財団</span>
+      </a>
+      <div class="hidden md:flex items-center gap-8 text-sm font-medium text-brown-700">
+        <a href="/#freedoms" class="hover:text-karaage-gold transition-colors">4つの自由</a>
+        <a href="/#manifesto" class="hover:text-karaage-gold transition-colors">宣言</a>
+        <a href="/#about" class="hover:text-karaage-gold transition-colors">概要</a>
+      </div>
+    </div>
+  </nav>
+
+  <!-- Content -->
+  <main class="pt-24 pb-24 px-6 min-h-screen bg-cream-100">
+    <div class="max-w-3xl mx-auto">
+
+      <div class="mb-12">
+        <p class="text-karaage-gold font-medium tracking-widest uppercase text-sm mb-4">Privacy Policy</p>
+        <h1 class="font-serif text-4xl md:text-5xl font-bold text-brown-900 mb-4">プライバシーポリシー</h1>
+        <p class="text-brown-500 text-sm">最終更新: 2025年4月15日</p>
+      </div>
+
+      <div class="space-y-12 text-brown-700 leading-relaxed">
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">1. はじめに</h2>
+          <p>
+            自由からあげ財団（以下「当財団」）は、本ウェブサイト（https://free-karaage.foundation/）の利用者のプライバシーを尊重します。
+            本ポリシーでは、当財団がどのような情報を収集し、どのように利用するかについて説明します。
+          </p>
+        </section>
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">2. Google Analytics について</h2>
+          <p class="mb-4">
+            当サイトでは、アクセス状況を把握するために <strong>Google Analytics 4</strong>（Google LLC 提供）を利用しています。
+            Google Analytics は、Cookie およびそれに類する技術を使用して、以下のような情報を自動的に収集します。
+          </p>
+          <ul class="space-y-2 list-disc list-inside text-brown-600">
+            <li>ページの閲覧数・滞在時間</li>
+            <li>参照元 URL</li>
+            <li>ブラウザの種類・OS・画面解像度</li>
+            <li>おおよその地域（国・都市レベル）</li>
+            <li>デバイスの種類</li>
+          </ul>
+          <p class="mt-4">
+            収集されたデータは Google のサーバーに送信・保存され、Google のプライバシーポリシーに従って管理されます。
+            当財団は、収集したデータをサイト改善の目的にのみ使用し、第三者に販売・提供しません。
+          </p>
+          <p class="mt-4">
+            Google のデータ利用については、
+            <a href="https://policies.google.com/privacy" class="text-karaage-gold hover:underline" target="_blank" rel="noopener">Google プライバシーポリシー</a>
+            をご確認ください。
+          </p>
+        </section>
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">3. Cookie について</h2>
+          <p>
+            Google Analytics の動作に際して、ブラウザに Cookie が保存される場合があります。
+            Cookie はブラウザの設定から無効化することができます。ただし、Cookie を無効にした場合でも、
+            当サイトのコンテンツ閲覧は引き続き可能です。
+          </p>
+        </section>
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">4. トラッキングのオプトアウト</h2>
+          <p class="mb-4">Google Analytics によるデータ収集を望まない場合、以下の方法でオプトアウトできます。</p>
+          <ul class="space-y-3 list-disc list-inside text-brown-600">
+            <li>
+              <a href="https://tools.google.com/dlpage/gaoptout" class="text-karaage-gold hover:underline" target="_blank" rel="noopener">
+                Google Analytics オプトアウトアドオン
+              </a>
+              をブラウザにインストールする
+            </li>
+            <li>ブラウザの設定で「トラッキング拒否（Do Not Track）」を有効にする</li>
+            <li>ブラウザの設定で Cookie を無効にする</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">5. 外部リンクについて</h2>
+          <p>
+            当サイトには外部サイトへのリンクが含まれます。リンク先のプライバシーポリシーについては、
+            各サイトにてご確認ください。当財団は外部サイトの内容・プライバシー慣行について責任を負いません。
+          </p>
+        </section>
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">6. 本ポリシーの変更</h2>
+          <p>
+            当財団は、必要に応じて本プライバシーポリシーを改定することがあります。
+            変更後のポリシーは、本ページに掲載した時点から効力を生じます。
+          </p>
+        </section>
+
+        <section>
+          <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">7. お問い合わせ</h2>
+          <p>
+            本ポリシーに関するご質問は、
+            <a href="https://github.com/cyber-gene/fkf/issues" class="text-karaage-gold hover:underline" target="_blank" rel="noopener">
+              GitHub Issues
+            </a>
+            よりお寄せください。
+          </p>
+        </section>
+
+      </div>
+
+      <div class="mt-16 pt-8 border-t border-cream-200">
+        <a href="/" class="inline-flex items-center gap-2 text-brown-500 hover:text-karaage-gold transition-colors text-sm">
+          ← トップページに戻る
+        </a>
+      </div>
+
+    </div>
+  </main>
+
+  <!-- Footer -->
+  <footer class="bg-brown-900 text-cream-200 py-12 px-6">
+    <div class="max-w-6xl mx-auto">
+      <div class="flex flex-col md:flex-row justify-between items-center gap-6">
+        <div class="flex items-center gap-3">
+          <img src="/favicon.svg" alt="からあげ" class="w-9 h-9 object-contain" />
+          <div>
+            <p class="font-serif font-bold text-cream-100">自由からあげ財団</p>
+            <p class="text-sm text-brown-600">食卓の自由を守る非営利団体</p>
+          </div>
+        </div>
+        <div class="flex gap-8 text-sm text-brown-500">
+          <a href="/#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
+          <a href="/#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
+          <a href="/#about" class="hover:text-karaage-amber transition-colors">概要</a>
+        </div>
+      </div>
+      <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600 space-y-2">
+        <p>
+          自由からあげ財団のコンテンツは、
+          <a href="https://www.gnu.org/licenses/copyleft.html" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
+            コピーレフト
+          </a>
+          の精神のもと自由に共有できます。
+        </p>
+        <p>
+          ソースコードは
+          <a href="https://github.com/cyber-gene/fkf" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
+            GitHub
+          </a>
+          にて AGPL-3.0 のもと公開しています。
+        </p>
+        <p>
+          <a href="/privacy" class="text-karaage-amber hover:underline">プライバシーポリシー</a>
+        </p>
+      </div>
+    </div>
+  </footer>
+
+</Layout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,5 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
 ---
 
 <Layout
@@ -7,20 +9,7 @@ import Layout from '../layouts/Layout.astro';
   description="自由からあげ財団のプライバシーポリシー。Google Analytics の利用とデータ収集について説明します。"
 >
 
-  <!-- Navigation -->
-  <nav class="fixed top-0 left-0 right-0 z-50 bg-cream-100/90 backdrop-blur-sm border-b border-cream-200">
-    <div class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/favicon.svg" alt="からあげ" class="w-7 h-7 object-contain" />
-        <span class="font-serif font-bold text-brown-900 text-sm tracking-wide">自由からあげ財団</span>
-      </a>
-      <div class="hidden md:flex items-center gap-8 text-sm font-medium text-brown-700">
-        <a href="/#freedoms" class="hover:text-karaage-gold transition-colors">4つの自由</a>
-        <a href="/#manifesto" class="hover:text-karaage-gold transition-colors">宣言</a>
-        <a href="/#about" class="hover:text-karaage-gold transition-colors">概要</a>
-      </div>
-    </div>
-  </nav>
+  <Header />
 
   <!-- Content -->
   <main class="pt-24 pb-24 px-6 min-h-screen bg-cream-100">
@@ -45,7 +34,7 @@ import Layout from '../layouts/Layout.astro';
         <section>
           <h2 class="font-serif text-2xl font-bold text-brown-900 mb-4">2. Google Analytics について</h2>
           <p class="mb-4">
-            当サイトでは、アクセス状況を把握するために <strong>Google Analytics 4</strong>（Google LLC 提供）を利用しています。
+            当サイトでは、アクセス状況を把握するために、設定されている場合に限り <strong>Google Analytics 4</strong>（Google LLC 提供）を利用します。
             Google Analytics は、Cookie およびそれに類する技術を使用して、以下のような情報を自動的に収集します。
           </p>
           <ul class="space-y-2 list-disc list-inside text-brown-600">
@@ -128,43 +117,6 @@ import Layout from '../layouts/Layout.astro';
     </div>
   </main>
 
-  <!-- Footer -->
-  <footer class="bg-brown-900 text-cream-200 py-12 px-6">
-    <div class="max-w-6xl mx-auto">
-      <div class="flex flex-col md:flex-row justify-between items-center gap-6">
-        <div class="flex items-center gap-3">
-          <img src="/favicon.svg" alt="からあげ" class="w-9 h-9 object-contain" />
-          <div>
-            <p class="font-serif font-bold text-cream-100">自由からあげ財団</p>
-            <p class="text-sm text-brown-600">食卓の自由を守る非営利団体</p>
-          </div>
-        </div>
-        <div class="flex gap-8 text-sm text-brown-500">
-          <a href="/#freedoms" class="hover:text-karaage-amber transition-colors">4つの自由</a>
-          <a href="/#manifesto" class="hover:text-karaage-amber transition-colors">宣言</a>
-          <a href="/#about" class="hover:text-karaage-amber transition-colors">概要</a>
-        </div>
-      </div>
-      <div class="mt-8 pt-8 border-t border-brown-800 text-center text-sm text-brown-600 space-y-2">
-        <p>
-          自由からあげ財団のコンテンツは、
-          <a href="https://www.gnu.org/licenses/copyleft.html" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
-            コピーレフト
-          </a>
-          の精神のもと自由に共有できます。
-        </p>
-        <p>
-          ソースコードは
-          <a href="https://github.com/cyber-gene/fkf" class="text-karaage-amber hover:underline" target="_blank" rel="noopener">
-            GitHub
-          </a>
-          にて AGPL-3.0 のもと公開しています。
-        </p>
-        <p>
-          <a href="/privacy" class="text-karaage-amber hover:underline">プライバシーポリシー</a>
-        </p>
-      </div>
-    </div>
-  </footer>
+  <Footer />
 
 </Layout>


### PR DESCRIPTION
## Summary

- Google Analytics 使用に伴い、プライバシーポリシーページ（`/privacy`）を新規作成
- データ収集内容、Cookie の説明、オプトアウト方法（GA アドオン・DNT・Cookie無効化）を記載
- サイト URL を `https://free-karaage.foundation/` として明記
- フッターにプライバシーポリシーへのリンクを追加（`index.astro` および `privacy.astro` 内フッター）

## Test plan

- [ ] `/privacy` にアクセスしてページが表示されること
- [ ] フッターの「プライバシーポリシー」リンクをクリックして `/privacy` に遷移すること
- [ ] ナビゲーションのロゴからトップページに戻れること

🤖 Generated with [Claude Code](https://claude.com/claude-code)