### PR TITLE
Dependabot で npm 依存関係を週次自動更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を追加
- npm パッケージを毎週月曜 09:00（JST）に自動チェック
- PR の上限は 10 件

## Test plan

- [ ] GitHub リポジトリの Settings > Security > Code security and analysis で Dependabot が有効になっていることを確認
- [ ] 次の月曜日以降に Dependabot PR が自動作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)