### PR TITLE
全ページに Link ヘッダーでサイトマップを明示

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,8 @@
 
 [build.environment]
   NODE_VERSION = "22"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Link = "<https://free-karaage.foundation/sitemap-index.xml>; rel=\"sitemap\""


### PR DESCRIPTION
## Summary

- `netlify.toml` に `[[headers]]` セクションを追加
- 全ページのレスポンスに `Link: <https://free-karaage.foundation/sitemap-index.xml>; rel="sitemap"` ヘッダーを付与
- AIエージェントやクローラーがHTTPヘッダーからサイトマップを自動検出できるようになる

## Test plan

- [ ] デプロイ後に `curl -I https://free-karaage.foundation/` で `Link` ヘッダーが返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)