### PR TITLE
fix: overflow-wrap を :root から body に移動、index.astro に <main> タグを追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,8 @@ import Footer from '../components/Footer.astro';
 
   <Header />
 
+  <main>
+
   <!-- Hero -->
   <section class="min-h-screen flex flex-col items-center justify-center px-6 pt-20 pb-16 text-center relative overflow-hidden">
     <!-- Background decoration -->
@@ -240,6 +242,8 @@ import Footer from '../components/Footer.astro';
       </div>
     </div>
   </section>
+
+  </main>
 
   <Footer />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,7 +20,7 @@
 }
 
 /* 長い単語や文字列のはみ出し防止 */
-:root {
+body {
   overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
## 修正内容

### #29: overflow-wrap を `:root` から `body` に移動
- `src/styles/global.css` の `overflow-wrap: break-word` を `:root` から `body` に変更
- `:root` はCSS変数（カスタムプロパティ）の定義に使うのが慣例

### #22: index.astro に `<main>` タグを追加（アクセシビリティ）
- `<Header />` と `<Footer />` の間のコンテンツを `<main>` タグで囲む
- スクリーンリーダー等の支援技術が主コンテンツを正しく識別できるように改善

## テスト
- `npm run build` ✅ ビルド成功
- Codex レビュー ✅ 問題なし

Closes #22, Closes #29