### PR TITLE
feat: Cookie 同意バナーを追加し GA を同意後のみ読み込む (#26)

### DIFF
--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -1,0 +1,87 @@
+---
+// Cookie 同意バナー — 初回訪問時に表示し、同意後のみ GA を読み込む
+interface Props {
+  gaMeasurementId?: string;
+}
+const { gaMeasurementId } = Astro.props;
+---
+
+<div
+  id="cookie-banner"
+  role="dialog"
+  aria-labelledby="cookie-banner-title"
+  aria-modal="false"
+  class="fixed bottom-0 left-0 right-0 z-50 hidden bg-brown-900/95 backdrop-blur-sm border-t-2 border-karaage-gold/60 px-4 py-5 shadow-2xl"
+>
+  <div class="max-w-4xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
+    <div class="flex-1 text-sm text-cream-100 leading-relaxed">
+      <p id="cookie-banner-title" class="font-bold text-karaage-light mb-1">🍗 Cookie についてのお知らせ</p>
+      <p>
+        当サイトでは、アクセス解析のために Google Analytics を使用しています。
+        同意いただける場合は「同意する」をクリックしてください。
+        <a href="/privacy" class="underline text-karaage-amber hover:text-karaage-light transition-colors">プライバシーポリシー</a>
+      </p>
+    </div>
+    <div class="flex gap-3 shrink-0">
+      <button
+        id="cookie-decline"
+        class="px-4 py-2 text-sm rounded border border-cream-200/40 text-cream-200 hover:bg-cream-200/10 transition-colors cursor-pointer"
+      >
+        拒否する
+      </button>
+      <button
+        id="cookie-accept"
+        class="px-4 py-2 text-sm rounded bg-karaage-gold hover:bg-karaage-amber text-white font-bold transition-colors cursor-pointer"
+      >
+        同意する
+      </button>
+    </div>
+  </div>
+</div>
+
+<script define:vars={{ gaMeasurementId }}>
+  const STORAGE_KEY = 'ga_consent';
+  const banner = document.getElementById('cookie-banner');
+
+  function loadGA() {
+    if (!gaMeasurementId) return;
+    const script = document.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`;
+    document.head.appendChild(script);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { window.dataLayer.push(arguments); }
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', gaMeasurementId);
+  }
+
+  function hideBanner() {
+    if (banner) banner.classList.add('hidden');
+  }
+
+  function showBanner() {
+    if (banner) banner.classList.remove('hidden');
+  }
+
+  // 既存の同意状態を確認
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'granted') {
+    loadGA();
+  } else if (stored !== 'denied') {
+    // 未決定の場合のみバナーを表示
+    showBanner();
+  }
+
+  document.getElementById('cookie-accept')?.addEventListener('click', () => {
+    localStorage.setItem(STORAGE_KEY, 'granted');
+    hideBanner();
+    loadGA();
+  });
+
+  document.getElementById('cookie-decline')?.addEventListener('click', () => {
+    localStorage.setItem(STORAGE_KEY, 'denied');
+    hideBanner();
+  });
+</script>

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -44,20 +44,26 @@ const { gaMeasurementId } = Astro.props;
 
 <script define:vars={{ gaMeasurementId }}>
   const STORAGE_KEY = 'ga_consent';
+  const GA_SCRIPT_ID = 'ga-gtag-script';
   const banner = document.getElementById('cookie-banner');
+  let gaLoaded = false;
 
   function loadGA() {
-    if (!gaMeasurementId) return;
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`;
-    document.head.appendChild(script);
+    if (!gaMeasurementId || gaLoaded) return;
+
+    if (!document.getElementById(GA_SCRIPT_ID)) {
+      const script = document.createElement('script');
+      script.id = GA_SCRIPT_ID;
+      script.async = true;
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`;
+      document.head.appendChild(script);
+    }
 
     window.dataLayer = window.dataLayer || [];
-    function gtag() { window.dataLayer.push(arguments); }
-    window.gtag = gtag;
-    gtag('js', new Date());
-    gtag('config', gaMeasurementId);
+    window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
+    window.gtag('js', new Date());
+    window.gtag('config', gaMeasurementId);
+    gaLoaded = true;
   }
 
   function hideBanner() {
@@ -68,9 +74,6 @@ const { gaMeasurementId } = Astro.props;
     if (banner) banner.classList.remove('hidden');
   }
 
-  // GA が設定されていない場合は何もしない
-  if (!gaMeasurementId) return;
-
   function getConsent() {
     try { return localStorage.getItem(STORAGE_KEY); } catch { return null; }
   }
@@ -79,23 +82,26 @@ const { gaMeasurementId } = Astro.props;
     try { localStorage.setItem(STORAGE_KEY, value); } catch { /* ignore */ }
   }
 
-  // 既存の同意状態を確認
-  const stored = getConsent();
-  if (stored === 'granted') {
-    loadGA();
-  } else if (stored !== 'denied') {
-    // 未決定の場合のみバナーを表示
-    showBanner();
+  // GA が設定されていない場合は何もしない
+  if (gaMeasurementId) {
+    // 既存の同意状態を確認
+    const stored = getConsent();
+    if (stored === 'granted') {
+      loadGA();
+    } else if (stored !== 'denied') {
+      // 未決定の場合のみバナーを表示
+      showBanner();
+    }
+
+    document.getElementById('cookie-accept')?.addEventListener('click', () => {
+      saveConsent('granted');
+      hideBanner();
+      loadGA();
+    });
+
+    document.getElementById('cookie-decline')?.addEventListener('click', () => {
+      saveConsent('denied');
+      hideBanner();
+    });
   }
-
-  document.getElementById('cookie-accept')?.addEventListener('click', () => {
-    saveConsent('granted');
-    hideBanner();
-    loadGA();
-  });
-
-  document.getElementById('cookie-decline')?.addEventListener('click', () => {
-    saveConsent('denied');
-    hideBanner();
-  });
 </script>

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -15,7 +15,10 @@ const { gaMeasurementId } = Astro.props;
 >
   <div class="max-w-4xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
     <div class="flex-1 text-sm text-cream-100 leading-relaxed">
-      <p id="cookie-banner-title" class="font-bold text-karaage-light mb-1">🍗 Cookie についてのお知らせ</p>
+      <p id="cookie-banner-title" class="font-bold text-karaage-light mb-1 flex items-center gap-2">
+        <img src="/favicon.svg" alt="" aria-hidden="true" class="w-5 h-5 object-contain" />
+        Cookie についてのお知らせ
+      </p>
       <p>
         当サイトでは、アクセス解析のために Google Analytics を使用しています。
         同意いただける場合は「同意する」をクリックしてください。

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -8,17 +8,16 @@ const { gaMeasurementId } = Astro.props;
 
 <div
   id="cookie-banner"
-  role="dialog"
+  role="region"
   aria-labelledby="cookie-banner-title"
-  aria-modal="false"
   class="fixed bottom-0 left-0 right-0 z-50 hidden bg-brown-900/95 backdrop-blur-sm border-t-2 border-karaage-gold/60 px-4 py-5 shadow-2xl"
 >
   <div class="max-w-4xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
     <div class="flex-1 text-sm text-cream-100 leading-relaxed">
-      <p id="cookie-banner-title" class="font-bold text-karaage-light mb-1 flex items-center gap-2">
+      <h2 id="cookie-banner-title" class="font-bold text-karaage-light mb-1 flex items-center gap-2">
         <img src="/favicon.svg" alt="" aria-hidden="true" class="w-5 h-5 object-contain" />
         Cookie についてのお知らせ
-      </p>
+      </h2>
       <p>
         当サイトでは、アクセス解析のために Google Analytics を使用しています。
         同意いただける場合は「同意する」をクリックしてください。
@@ -28,12 +27,14 @@ const { gaMeasurementId } = Astro.props;
     <div class="flex gap-3 shrink-0">
       <button
         id="cookie-decline"
+        type="button"
         class="px-4 py-2 text-sm rounded border border-cream-200/40 text-cream-200 hover:bg-cream-200/10 transition-colors cursor-pointer"
       >
         拒否する
       </button>
       <button
         id="cookie-accept"
+        type="button"
         class="px-4 py-2 text-sm rounded bg-karaage-gold hover:bg-karaage-amber text-white font-bold transition-colors cursor-pointer"
       >
         同意する

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -68,8 +68,16 @@ const { gaMeasurementId } = Astro.props;
   // GA が設定されていない場合は何もしない
   if (!gaMeasurementId) return;
 
+  function getConsent() {
+    try { return localStorage.getItem(STORAGE_KEY); } catch { return null; }
+  }
+
+  function saveConsent(value) {
+    try { localStorage.setItem(STORAGE_KEY, value); } catch { /* ignore */ }
+  }
+
   // 既存の同意状態を確認
-  const stored = localStorage.getItem(STORAGE_KEY);
+  const stored = getConsent();
   if (stored === 'granted') {
     loadGA();
   } else if (stored !== 'denied') {
@@ -78,13 +86,13 @@ const { gaMeasurementId } = Astro.props;
   }
 
   document.getElementById('cookie-accept')?.addEventListener('click', () => {
-    localStorage.setItem(STORAGE_KEY, 'granted');
+    saveConsent('granted');
     hideBanner();
     loadGA();
   });
 
   document.getElementById('cookie-decline')?.addEventListener('click', () => {
-    localStorage.setItem(STORAGE_KEY, 'denied');
+    saveConsent('denied');
     hideBanner();
   });
 </script>

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -65,6 +65,9 @@ const { gaMeasurementId } = Astro.props;
     if (banner) banner.classList.remove('hidden');
   }
 
+  // GA が設定されていない場合は何もしない
+  if (!gaMeasurementId) return;
+
   // 既存の同意状態を確認
   const stored = localStorage.getItem(STORAGE_KEY);
   if (stored === 'granted') {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import CookieBanner from '../components/CookieBanner.astro';
 
 interface Props {
   title: string;
@@ -45,20 +46,9 @@ const ogImageURL = new URL(ogImage, Astro.site);
     <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&family=BIZ+UDPMincho:wght@400;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0&icon_names=keyboard_double_arrow_down" rel="stylesheet" />
     <title>{title}</title>
-    {gaMeasurementId && (
-      <>
-        <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}></script>
-        <script define:vars={{ gaMeasurementId }}>
-          window.dataLayer = window.dataLayer || [];
-          function gtag() { window.dataLayer.push(arguments); }
-          window.gtag = gtag;
-          gtag('js', new Date());
-          gtag('config', gaMeasurementId);
-        </script>
-      </>
-    )}
   </head>
   <body class="bg-cream-100 text-brown-900 font-sans antialiased">
     <slot />
+    <CookieBanner gaMeasurementId={gaMeasurementId} />
   </body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,6 +49,6 @@ const ogImageURL = new URL(ogImage, Astro.site);
   </head>
   <body class="bg-cream-100 text-brown-900 font-sans antialiased">
     <slot />
-    <CookieBanner gaMeasurementId={gaMeasurementId} />
+    {gaMeasurementId && <CookieBanner gaMeasurementId={gaMeasurementId} />}
   </body>
 </html>


### PR DESCRIPTION
## 概要

- `CookieBanner.astro` を新規作成し、初回訪問時に Cookie 同意バナーを表示
- **同意前は GA スクリプトを一切読み込まない**（GDPR・個人情報保護法対応）
- 同意・拒否の状態を `localStorage` に保存し、再訪時はバナーを表示しない
- `Layout.astro` のインライン GA 読み込みを `CookieBanner` に移管

## 実装の詳細

| 状態 | 挙動 |
|---|---|
| 初回訪問（未決定） | バナーを表示、GA は読み込まない |
| 「同意する」クリック | バナーを閉じ GA を動的に読み込む、`ga_consent=granted` を保存 |
| 「拒否する」クリック | バナーを閉じ GA は読み込まない、`ga_consent=denied` を保存 |
| 再訪（granted） | バナー非表示・GA を自動読み込み |
| 再訪（denied） | バナー非表示・GA は読み込まない |
| GA 未設定環境 | バナー自体を表示しない |

## 品質

- [x] `npm run build` 通過
- [x] Codex レビュー 3 回実施（指摘事項をすべて修正済み）
  - P3: GA 未設定時はバナーを表示しない → `if (!gaMeasurementId) return` で対応
  - P2: `localStorage` 書き込み失敗時もバナーを閉じられるよう try-catch を追加

Closes #26

🤖 Generated with [Claude Code](https://claude.ai/claude-code)