### PR TITLE
fix: Material Symbols フォントをインライン SVG に置き換え

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,7 +20,6 @@ const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=BIZ+UDPGothic:wght@400;700&family=BIZ+UDPMincho:wght@400;700&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,300,0,0&icon_names=keyboard_double_arrow_down" rel="stylesheet" />
     <title>{title}</title>
     {gaMeasurementId && (
       <>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,6 +41,7 @@ import Footer from '../components/Footer.astro';
 
     <!-- Scroll hint -->
     <div class="absolute bottom-10 left-1/2 -translate-x-1/2 flex flex-col items-center text-brown-400">
+      <span class="sr-only">下にスクロール</span>
       <svg class="animate-bounce" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M7.41 7.84 12 12.42l4.59-4.58L18 9.25l-6 6-6-6 1.41-1.41zm0 6 4.59 4.58L16.59 13.84 18 15.25l-6 6-6-6 1.41-1.41z"/>
       </svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,7 +41,9 @@ import Footer from '../components/Footer.astro';
 
     <!-- Scroll hint -->
     <div class="absolute bottom-10 left-1/2 -translate-x-1/2 flex flex-col items-center text-brown-400">
-      <span class="material-symbols-outlined animate-bounce" style="font-size: 28px;">keyboard_double_arrow_down</span>
+      <svg class="animate-bounce" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M7.41 7.84 12 12.42l4.59-4.58L18 9.25l-6 6-6-6 1.41-1.41zm0 6 4.59 4.58L16.59 13.84 18 15.25l-6 6-6-6 1.41-1.41z"/>
+      </svg>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

- `src/layouts/Layout.astro` から Material Symbols（Google Fonts）の `<link>` タグを削除
- `src/pages/index.astro` のスクロールヒント矢印を `<span class="material-symbols-outlined">` からインライン SVG に置き換え

アイコン1つのためだけに発生していた Google Fonts への余分なネットワークリクエストを削減する。

Closes #25

## Test plan

- [ ] `npm run build` がエラーなく完了する
- [ ] トップページのスクロールヒント下向き二重矢印が正常に表示される
- [ ] `animate-bounce` アニメーションが機能する
- [ ] Network タブで Material Symbols のフォントリクエストが発生していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)