### PR TITLE
ci: PR 時にビルド・lint・フォーマットチェックを実行する GitHub Actions を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Tokyo'
+    labels:
+      - 'dependencies'
+
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run format:check


### PR DESCRIPTION
## Summary

- PR 作成・更新時に自動で CI が走るよう GitHub Actions ワークフロー (`.github/workflows/ci.yml`) を追加
- `build` ジョブ: `npm ci` → `npm run build` でビルドの成功を確認
- `lint` ジョブ: `npm run lint` → `npm run format:check` で lint とフォーマットを確認
- 2 ジョブは並列実行されるため高速

## Test plan

- [ ] PR 作成後に Actions タブで `build` / `Lint & Format` の 2 ジョブが実行されることを確認
- [ ] 両ジョブが green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)