### PR TITLE
feat: Content Security Policy ヘッダーを実装

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,4 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), payment=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://*.googletagmanager.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"

--- a/public/cookie-consent.js
+++ b/public/cookie-consent.js
@@ -1,0 +1,73 @@
+(function () {
+  const STORAGE_KEY = 'ga_consent'
+  const GA_SCRIPT_ID = 'ga-gtag-script'
+  const banner = document.getElementById('cookie-banner')
+  const gaMeasurementId = banner?.dataset.gaId
+  let gaLoaded = false
+
+  function loadGA() {
+    if (!gaMeasurementId || gaLoaded) return
+
+    if (!document.getElementById(GA_SCRIPT_ID)) {
+      const script = document.createElement('script')
+      script.id = GA_SCRIPT_ID
+      script.async = true
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`
+      document.head.appendChild(script)
+    }
+
+    window.dataLayer = window.dataLayer || []
+    window.gtag =
+      window.gtag ||
+      function () {
+        window.dataLayer.push(arguments)
+      }
+    window.gtag('js', new Date())
+    window.gtag('config', gaMeasurementId)
+    gaLoaded = true
+  }
+
+  function hideBanner() {
+    if (banner) banner.classList.add('hidden')
+  }
+
+  function showBanner() {
+    if (banner) banner.classList.remove('hidden')
+  }
+
+  function getConsent() {
+    try {
+      return localStorage.getItem(STORAGE_KEY)
+    } catch {
+      return null
+    }
+  }
+
+  function saveConsent(value) {
+    try {
+      localStorage.setItem(STORAGE_KEY, value)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (!gaMeasurementId) return
+
+  const stored = getConsent()
+  if (stored === 'granted') {
+    loadGA()
+  } else if (stored !== 'denied') {
+    showBanner()
+  }
+
+  document.getElementById('cookie-accept')?.addEventListener('click', () => {
+    saveConsent('granted')
+    hideBanner()
+    loadGA()
+  })
+
+  document.getElementById('cookie-decline')?.addEventListener('click', () => {
+    saveConsent('denied')
+    hideBanner()
+  })
+})()

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -10,6 +10,7 @@ const { gaMeasurementId } = Astro.props
   id="cookie-banner"
   role="region"
   aria-labelledby="cookie-banner-title"
+  data-ga-id={gaMeasurementId}
   class="fixed bottom-0 left-0 right-0 z-50 hidden bg-brown-900/95 backdrop-blur-sm border-t-2 border-karaage-gold/60 px-4 py-5 shadow-2xl"
 >
   <div class="max-w-4xl mx-auto flex flex-col sm:flex-row items-start sm:items-center gap-4">
@@ -50,78 +51,4 @@ const { gaMeasurementId } = Astro.props
   </div>
 </div>
 
-<script define:vars={{ gaMeasurementId }}>
-  const STORAGE_KEY = 'ga_consent'
-  const GA_SCRIPT_ID = 'ga-gtag-script'
-  const banner = document.getElementById('cookie-banner')
-  let gaLoaded = false
-
-  function loadGA() {
-    if (!gaMeasurementId || gaLoaded) return
-
-    if (!document.getElementById(GA_SCRIPT_ID)) {
-      const script = document.createElement('script')
-      script.id = GA_SCRIPT_ID
-      script.async = true
-      script.src = `https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`
-      document.head.appendChild(script)
-    }
-
-    window.dataLayer = window.dataLayer || []
-    window.gtag =
-      window.gtag ||
-      function () {
-        window.dataLayer.push(arguments)
-      }
-    window.gtag('js', new Date())
-    window.gtag('config', gaMeasurementId)
-    gaLoaded = true
-  }
-
-  function hideBanner() {
-    if (banner) banner.classList.add('hidden')
-  }
-
-  function showBanner() {
-    if (banner) banner.classList.remove('hidden')
-  }
-
-  function getConsent() {
-    try {
-      return localStorage.getItem(STORAGE_KEY)
-    } catch {
-      return null
-    }
-  }
-
-  function saveConsent(value) {
-    try {
-      localStorage.setItem(STORAGE_KEY, value)
-    } catch {
-      /* ignore */
-    }
-  }
-
-  // GA が設定されていない場合は何もしない
-  if (gaMeasurementId) {
-    // 既存の同意状態を確認
-    const stored = getConsent()
-    if (stored === 'granted') {
-      loadGA()
-    } else if (stored !== 'denied') {
-      // 未決定の場合のみバナーを表示
-      showBanner()
-    }
-
-    document.getElementById('cookie-accept')?.addEventListener('click', () => {
-      saveConsent('granted')
-      hideBanner()
-      loadGA()
-    })
-
-    document.getElementById('cookie-decline')?.addEventListener('click', () => {
-      saveConsent('denied')
-      hideBanner()
-    })
-  }
-</script>
+<script src="/cookie-consent.js" defer></script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,7 +57,7 @@ import Footer from '../components/Footer.astro'
       <div
         class="absolute bottom-10 left-1/2 -translate-x-1/2 flex flex-col items-center text-brown-400"
       >
-        <span class="material-symbols-outlined animate-bounce" style="font-size: 28px;"
+        <span class="material-symbols-outlined animate-bounce text-[28px]"
           >keyboard_double_arrow_down</span
         >
       </div>
@@ -292,9 +292,3 @@ import Footer from '../components/Footer.astro'
 
   <Footer />
 </Layout>
-
-<style>
-  html {
-    scroll-behavior: smooth;
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -24,6 +24,10 @@ body {
   overflow-wrap: break-word;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 h2,
 h3,
 h4,


### PR DESCRIPTION
## 概要

CSP ヘッダーを実装し、XSS 等のインジェクション攻撃リスクを低減します。`unsafe-inline` を使わない厳格な CSP を実現するため、インラインスクリプト・スタイルの除去も同時に行います。

## 変更内容

### `netlify.toml` — CSP ヘッダー追加
| ディレクティブ | 許可先 | 目的 |
|---|---|---|
| `script-src` | `'self'` `*.googletagmanager.com` | GA スクリプト |
| `style-src` | `'self'` `fonts.googleapis.com` | Google Fonts CSS |
| `font-src` | `'self'` `fonts.gstatic.com` | Google Fonts ファイル |
| `img-src` | `'self'` `data:` GA/GTM ドメイン | トラッキングピクセル |
| `connect-src` | `'self'` `*.google-analytics.com` 等 | GA ビーコン |
| `object-src` / `frame-src` | `'none'` | 埋め込み禁止 |
| `frame-ancestors` | `'none'` | クリックジャッキング防止（CSP版）|
| `base-uri` / `form-action` | `'self'` | DOM ベース XSS 対策 |

### `'unsafe-inline'` を不要にするリファクタリング
- **`CookieBanner.astro`**: `<script define:vars>` (インライン) → `<script src="/cookie-consent.js" defer>` (外部ファイル)
  - GA Measurement ID は `data-ga-id` 属性経由で受け渡し
- **`public/cookie-consent.js`**: 外部スクリプトとして新規作成
- **`index.astro`**: `style="font-size:28px"` → Tailwind クラス `text-[28px]` に変換
- **`index.astro`**: `<style>` ブロックを削除 → `global.css` に移動

## テスト
- `npm run build` ✅
- ビルド出力にインライン `style=` / `<script>` がゼロであることを確認 ✅
- Codex レビュー ✅ 問題なし