### PR TITLE
chore: dependabot を週次から日次スケジュールに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'daily'
       time: '09:00'
       timezone: 'Asia/Tokyo'
     labels:
@@ -13,8 +12,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'daily'
       time: '09:00'
       timezone: 'Asia/Tokyo'
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

- `github-actions` と `npm` 両エコシステムの Dependabot スケジュールを `weekly`（月曜）から `daily` に変更
- `day` フィールドは `daily` では不要なため削除

## Test plan

- [ ] `.github/dependabot.yml` の `interval` が両エコシステムで `daily` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)