### PR TITLE
fix: Cookie同意バナーの文言を明確化

### DIFF
--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -24,12 +24,11 @@ const { gaMeasurementId } = Astro.props
       </h2>
       <p>
         当サイトでは、アクセス解析のために Google Analytics を使用しています。
-        同意いただける場合は「同意する」をクリックしてください。
-        <a
+        Cookie の使用に同意いただける場合は「同意する」をクリックしてください。詳細は<a
           href="/privacy"
           class="underline text-karaage-amber hover:text-karaage-light transition-colors"
           >プライバシーポリシー</a
-        >
+        >をご覧ください。
       </p>
     </div>
     <div class="flex gap-3 shrink-0">

--- a/src/components/CookieBanner.astro
+++ b/src/components/CookieBanner.astro
@@ -23,8 +23,8 @@ const { gaMeasurementId } = Astro.props
         Cookie についてのお知らせ
       </h2>
       <p>
-        当サイトでは、アクセス解析のために Google Analytics を使用しています。
-        Cookie の使用に同意いただける場合は「同意する」をクリックしてください。詳細は<a
+        当サイトでは、アクセス解析のために Google Analytics を使用しています。 Cookie
+        の使用に同意いただける場合は「同意する」をクリックしてください。詳細は<a
           href="/privacy"
           class="underline text-karaage-amber hover:text-karaage-light transition-colors"
           >プライバシーポリシー</a


### PR DESCRIPTION
## Summary

- 「同意いただける場合は」という主語のない文を「Cookie の使用に同意いただける場合は」に修正し、何への同意かを明示
- プライバシーポリシーリンクを「詳細は〜をご覧ください」という自然な文脈で統合

## Test plan

- [ ] バナーの文言が正しく表示されること
- [ ] プライバシーポリシーリンクが正常に動作すること
- [ ] 「同意する」「拒否する」ボタンが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)